### PR TITLE
Copy commit URL to clipboard and display a top-right message when clicking on a data point in a chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 </head>
 
 <body>
-  <div id="notification" class="notification hidden">Commit URL copied to clipboard</div>
+  <div id="notification" class="notification hidden"></div>
   <script>
     function unzip(entries) {
       const res = new Map();

--- a/index.html
+++ b/index.html
@@ -17,8 +17,7 @@
       display: none;
     }
 
-    .inline-text {
-      display: inline-block;
+    .notification {
       position: fixed;
       top: 1em;
       right: 1em;
@@ -31,7 +30,7 @@
 </head>
 
 <body>
-  <p id="notify-clipboard-text" class="hidden"></p>
+  <div id="notification" class="notification hidden">Commit URL copied to clipboard</div>
   <script>
     function unzip(entries) {
       const res = new Map();
@@ -52,12 +51,12 @@
       return res;
     }
 
-    function show_clipboard_text(text) {
-      var notifyClipboardTextElem = document.getElementById("notify-clipboard-text");
-      notifyClipboardTextElem.textContent = text + " copied to clipboard";
-      notifyClipboardTextElem.className = 'inline-text';
+    function show_notification(text) {
+      var notificationElem = document.getElementById('notification');
+      notificationElem.innerHTML = '<b>' + text + '</b> copied to clipboard';
+      notificationElem.classList.remove('hidden');
       setTimeout(function () {
-        notifyClipboardTextElem.className = 'hidden';
+        notificationElem.classList.add('hidden');
       }, 3000);
     }
 
@@ -65,7 +64,7 @@
       const commit_hash = data.points[0].x;
       const url = `https://github.com/rust-analyzer/rust-analyzer/commit/${commit_hash}`;
       navigator.clipboard.writeText(url);
-      show_clipboard_text(url);
+      show_notification(url);
     }
 
     async function main() {

--- a/index.html
+++ b/index.html
@@ -12,10 +12,76 @@
       align-items: center;
       flex-direction: column;
     }
+
+    .hidden {
+      display: none;
+    }
+
+    .inline-text {
+      display: inline-block;
+      position: fixed;
+      top: 0;
+      right: 0;
+      margin-right: 1em;
+      background-color: #FFF3CD;
+      padding: 10px;
+      color: #B3994E;
+    }
+
+    @-webkit-keyframes clipboard-text {
+      0% { display: none; }
+      100% { display: inline-block; }
+    }
+    @-moz-keyframes clipboard-text {
+      0% { display: none; }
+      100% { display: inline-block; }
+    }
+    @-o-keyframes clipboard-text {
+      0% { display: none; }
+      100% { display: inline-block; }
+    }
+    @keyframes clipboard-text {
+      0% { display: none; }
+      100% { display: inline-block; }
+    }
+
+    .clipboard-text-animated {
+      position: fixed;
+      top: 0;
+      right: 0;
+      background-color: #FFF3CD;
+      padding: 10px;
+      color: #B3994E;
+
+      -webkit-animation-name: clipboard-text;
+      -moz-animation-name: clipboard-text;
+      -o-animation-name: clipboard-text;
+      animation-name: clipboard-text;
+
+      -webkit-animation-duration: 4s;
+      -moz-animation-duration: 4s;
+      -o-animation-duration: 4s;
+      animation-duration: 4s;
+
+      -webkit-animation-iteration-count: 2;
+      -moz-animation-iteration-count: 2;
+      -o-animation-iteration-count: 2;
+      animation-iteration-count: 2;
+
+      -webkit-animation-direction: alternate;
+      -moz-animation-direction: alternate;
+      -o-animation-direction: alternate;
+      animation-direction: alternate;
+    }
   </style>
 </head>
 
 <body>
+  <div>
+    <p ></p>
+    <input id="clipboard-input" type="text" class="hidden" value="">
+    <p id="notify-clipboard-text" class="hidden"></p>
+  </div>
   <script>
     function unzip(entries) {
       const res = new Map();
@@ -33,7 +99,36 @@
           r.revision.push(entry.revision.substr(0, 6));
         }
       }
-      return res
+      return res;
+    }
+
+    function copy_to_clipboard(clipboardInputElem, text) {
+      clipboardInputElem.textContent = text;
+      clipboardInputElem.select();
+      clipboardInputElem.setSelectionRange(0, 99999); /* For mobile devices */
+
+      document.execCommand("copy");
+    }
+
+    function show_clipboard_text(commit_hash) {
+      var notifyClipboardTextElem = document.getElementById("notify-clipboard-text");
+      notifyClipboardTextElem.textContent = commit_hash + " copied to clipboard";
+      notifyClipboardTextElem.className = 'inline-text';
+      // notifyClipboardTextElem.className = 'hidden';
+      // notifyClipboardTextElem.textContent = commit_hash + " copied to clipboard";
+      // notifyClipboardTextElem.className = 'clipboard-text-animated';
+      setTimeout(function () {
+        notifyClipboardTextElem.className = 'hidden';
+      }, 3000);
+    }
+
+    function data_point_click(data) {
+      var commit_hash = data.points[0].x;
+      var clipboardInputElem = document.getElementById("clipboard-input");
+      copy_to_clipboard(clipboardInputElem, commit_hash);
+
+      document.execCommand("copy");
+      show_clipboard_text(commit_hash);
     }
 
     async function main() {
@@ -106,6 +201,7 @@
           }
         });
         Plotly.newPlot(plotDiv, definition.data, definition.layout);
+        plotDiv.on("plotly_click", data_point_click);
         body.appendChild(plotDiv);
       }
     }

--- a/index.html
+++ b/index.html
@@ -51,20 +51,13 @@
       return res;
     }
 
-    function show_notification(text) {
+    function show_notification(html_text) {
       var notificationElem = document.getElementById('notification');
-      notificationElem.innerHTML = '<b>' + text + '</b> copied to clipboard';
+      notificationElem.innerHTML = html_text;
       notificationElem.classList.remove('hidden');
       setTimeout(function () {
         notificationElem.classList.add('hidden');
       }, 3000);
-    }
-
-    function data_point_click(data) {
-      const commit_hash = data.points[0].x;
-      const url = `https://github.com/rust-analyzer/rust-analyzer/commit/${commit_hash}`;
-      navigator.clipboard.writeText(url);
-      show_notification(url);
     }
 
     async function main() {
@@ -137,7 +130,13 @@
           }
         });
         Plotly.newPlot(plotDiv, definition.data, definition.layout);
-        plotDiv.on("plotly_click", data_point_click);
+        plotDiv.on("plotly_click", (data) => {
+          const commit_hash = data.points[0].x;
+          const url = `https://github.com/rust-analyzer/rust-analyzer/commit/${commit_hash}`;
+          const notification_text = `Commit <b>${commit_hash}</b> URL copied to clipboard`;
+          navigator.clipboard.writeText(url);
+          show_notification(notification_text);
+        });
         body.appendChild(plotDiv);
       }
     }

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
           }
           const r = res.get(key);
           r.data.push(value);
-          r.revision.push(entry.revision.substr(0, 6));
+          r.revision.push(entry.revision.substr(0, 7));
         }
       }
       return res;

--- a/index.html
+++ b/index.html
@@ -26,62 +26,13 @@
       background-color: #FFF3CD;
       padding: 10px;
       color: #B3994E;
-    }
-
-    @-webkit-keyframes clipboard-text {
-      0% { display: none; }
-      100% { display: inline-block; }
-    }
-    @-moz-keyframes clipboard-text {
-      0% { display: none; }
-      100% { display: inline-block; }
-    }
-    @-o-keyframes clipboard-text {
-      0% { display: none; }
-      100% { display: inline-block; }
-    }
-    @keyframes clipboard-text {
-      0% { display: none; }
-      100% { display: inline-block; }
-    }
-
-    .clipboard-text-animated {
-      position: fixed;
-      top: 0;
-      right: 0;
-      background-color: #FFF3CD;
-      padding: 10px;
-      color: #B3994E;
-
-      -webkit-animation-name: clipboard-text;
-      -moz-animation-name: clipboard-text;
-      -o-animation-name: clipboard-text;
-      animation-name: clipboard-text;
-
-      -webkit-animation-duration: 4s;
-      -moz-animation-duration: 4s;
-      -o-animation-duration: 4s;
-      animation-duration: 4s;
-
-      -webkit-animation-iteration-count: 2;
-      -moz-animation-iteration-count: 2;
-      -o-animation-iteration-count: 2;
-      animation-iteration-count: 2;
-
-      -webkit-animation-direction: alternate;
-      -moz-animation-direction: alternate;
-      -o-animation-direction: alternate;
-      animation-direction: alternate;
+      z-index: 1;
     }
   </style>
 </head>
 
 <body>
-  <div>
-    <p ></p>
-    <input id="clipboard-input" type="text" class="hidden" value="">
-    <p id="notify-clipboard-text" class="hidden"></p>
-  </div>
+  <p id="notify-clipboard-text" class="hidden"></p>
   <script>
     function unzip(entries) {
       const res = new Map();
@@ -102,33 +53,20 @@
       return res;
     }
 
-    function copy_to_clipboard(clipboardInputElem, text) {
-      clipboardInputElem.textContent = text;
-      clipboardInputElem.select();
-      clipboardInputElem.setSelectionRange(0, 99999); /* For mobile devices */
-
-      document.execCommand("copy");
-    }
-
-    function show_clipboard_text(commit_hash) {
+    function show_clipboard_text(text) {
       var notifyClipboardTextElem = document.getElementById("notify-clipboard-text");
-      notifyClipboardTextElem.textContent = commit_hash + " copied to clipboard";
+      notifyClipboardTextElem.textContent = text + " copied to clipboard";
       notifyClipboardTextElem.className = 'inline-text';
-      // notifyClipboardTextElem.className = 'hidden';
-      // notifyClipboardTextElem.textContent = commit_hash + " copied to clipboard";
-      // notifyClipboardTextElem.className = 'clipboard-text-animated';
       setTimeout(function () {
         notifyClipboardTextElem.className = 'hidden';
       }, 3000);
     }
 
     function data_point_click(data) {
-      var commit_hash = data.points[0].x;
-      var clipboardInputElem = document.getElementById("clipboard-input");
-      copy_to_clipboard(clipboardInputElem, commit_hash);
-
-      document.execCommand("copy");
-      show_clipboard_text(commit_hash);
+      const commit_hash = data.points[0].x;
+      const url = `https://github.com/rust-analyzer/rust-analyzer/commit/${commit_hash}`;
+      navigator.clipboard.writeText(url);
+      show_clipboard_text(url);
     }
 
     async function main() {

--- a/index.html
+++ b/index.html
@@ -20,9 +20,8 @@
     .inline-text {
       display: inline-block;
       position: fixed;
-      top: 0;
-      right: 0;
-      margin-right: 1em;
+      top: 1em;
+      right: 1em;
       background-color: #FFF3CD;
       padding: 10px;
       color: #B3994E;


### PR DESCRIPTION
When clicking on a data point in a chart, the commit URL will be copied to clipboard and a top-right message will appear.

Tested on latest official builds of Chrome, Firefox and Edge.
Chrome: 88.0.4324.182 (64-bit)
Firefox: 85.0.2 (64-bit)
Edge: 88.0.705.74 (64-bit)
 