### PR TITLE
Include diesel results in other graphs

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,14 +96,14 @@
         let plotName = series;
         let seriesName;
         const analysisStatsPrefix = 'analysis-stats/';
-        const analysisStatsPrefixLength = analysisStatsPrefix.length;
         // Check for aggregated series of form "analysis-stats/<seriesName>/<plotName>"
-        //  - <seriesName> is the project (e.g. "ripgrep", "diesel/diesel")
+        //  - <seriesName> is the project (e.g. "ripgrep", "diesel")
         //  - <plotName> is the metric (e.g. "total memory", "total time"), it cannot contain a `/`
         if (plotName.startsWith(analysisStatsPrefix)) {
-          const p = plotName.lastIndexOf("/");
-          seriesName = plotName.substring(analysisStatsPrefixLength, p);
-          plotName = plotName.substring(p + 1);
+          const plotNameStart = plotName.lastIndexOf("/");
+          const seriesNameStart = plotName.lastIndexOf("/", plotNameStart - 1);
+          seriesName = plotName.substring(seriesNameStart + 1, plotNameStart);
+          plotName = plotName.substring(plotNameStart + 1);
         } else {
           seriesName = series;
         }


### PR DESCRIPTION
Previously due to the `/` in `diesel/diesel` it was excluded from the aggregated plots.
Now it is part of the said plots so it ease the comparison.
As diesel/diesel results have less history we need to specify the revisions order.